### PR TITLE
Set default clonedir for Git upstreams to "."

### DIFF
--- a/source/moss/format/source/upstream_definition.d
+++ b/source/moss/format/source/upstream_definition.d
@@ -59,7 +59,7 @@ struct GitUpstreamDefinition
     @YamlSchema("ref", true) string refID;
 
     /** Directory to clone the git source to */
-    @YamlSchema("clonedir") string clonedir;
+    @YamlSchema("clonedir") string clonedir = ".";
 }
 
 /**


### PR DESCRIPTION
For a Git upstream, we should set the default clone dir to also be ".", the same default directory for decompressing the contents of a plain upstream to. This way we ensure consistent location/behavior between plain and Git upstreams when only one upstream is present. If there are more than one, packagers have to specify the `clonedir` just like how they specify `unpackdir` for plain upstreams, otherwise files from different upstreams may clash with each other.
